### PR TITLE
fix: 🔐 introspect response

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/beego/beego/utils/pagination"
 	"github.com/casdoor/casdoor/object"
@@ -300,14 +301,45 @@ func (c *ApiController) ResponseTokenError(errorMsg string) {
 // @router /login/oauth/introspect [post]
 func (c *ApiController) IntrospectToken() {
 	tokenValue := c.Input().Get("token")
+
+	var introspectionResponse object.IntrospectionResponse
+
+	// 	https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
+	//
+	//	To prevent token scanning attacks, the endpoint MUST also require
+	// 	some form of authorization to access this endpoint, such as client
+	// 	authentication as described in OAuth 2.0 [RFC6749] or a separate
+	// 	OAuth 2.0 access token such as the bearer token described in OAuth
+	// 	2.0 Bearer Token Usage [RFC6750].  The methods of managing and
+	// 	validating these authentication credentials are out of scope of this
+	// 	specification.
 	clientId, clientSecret, ok := c.Ctx.Request.BasicAuth()
 	if !ok {
-		clientId = c.Input().Get("client_id")
-		clientSecret = c.Input().Get("client_secret")
-		if clientId == "" || clientSecret == "" {
-			c.ResponseTokenError(object.InvalidRequest)
-			return
-		}
+		//  TODO: Bearer parser with audience and checking privileges
+		//  Example
+		//  POST /introspect HTTP/1.1
+		//  Host: server.example.com
+		//  Accept: application/json
+		//  Content-Type: application/x-www-form-urlencoded
+		//  Authorization: Bearer 23410913-abewfq.123483
+		//
+		// token=2YotnFZFEjr1zCsicMWpAA
+		//
+		//
+		c.ResponseTokenError(c.T("basicAuth:Invalid BasicAuth credentials"))
+		return
+	}
+
+	tokenTypeHint := c.Input().Get("token_type_hint")
+	token, err := object.GetTokenByTokenValue(tokenValue, tokenTypeHint)
+	if err != nil {
+		c.ResponseTokenError(err.Error())
+		return
+	}
+	if token == nil {
+		c.Data["json"] = introspectionResponse
+		c.ServeJSON()
+		return
 	}
 
 	application, err := object.GetApplicationByClientId(clientId)
@@ -321,30 +353,13 @@ func (c *ApiController) IntrospectToken() {
 		return
 	}
 
-	tokenTypeHint := c.Input().Get("token_type_hint")
-	var token *object.Token
-	if tokenTypeHint != "" {
-		token, err = object.GetTokenByTokenValue(tokenValue, tokenTypeHint)
-		if err != nil {
-			c.ResponseTokenError(err.Error())
-			return
-		}
-		if token == nil {
-			c.Data["json"] = &object.IntrospectionResponse{Active: false}
-			c.ServeJSON()
-			return
-		}
-	}
-
-	var introspectionResponse object.IntrospectionResponse
-
 	if application.TokenFormat == "JWT-Standard" {
 		jwtToken, err := object.ParseStandardJwtTokenByApplication(tokenValue, application)
 		if err != nil || jwtToken.Valid() != nil {
 			// and token revoked case. but we not implement
 			// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
 			// refs: https://tools.ietf.org/html/rfc7009
-			c.Data["json"] = &object.IntrospectionResponse{Active: false}
+			c.Data["json"] = introspectionResponse
 			c.ServeJSON()
 			return
 		}
@@ -354,7 +369,6 @@ func (c *ApiController) IntrospectToken() {
 			Scope:     jwtToken.Scope,
 			ClientId:  clientId,
 			Username:  jwtToken.Name,
-			TokenType: jwtToken.TokenType,
 			Exp:       jwtToken.ExpiresAt.Unix(),
 			Iat:       jwtToken.IssuedAt.Unix(),
 			Nbf:       jwtToken.NotBefore.Unix(),
@@ -369,7 +383,7 @@ func (c *ApiController) IntrospectToken() {
 			// and token revoked case. but we not implement
 			// TODO: 2022-03-03 add token revoked check, when we implemented the Token Revocation(rfc7009) Specs.
 			// refs: https://tools.ietf.org/html/rfc7009
-			c.Data["json"] = &object.IntrospectionResponse{Active: false}
+			c.Data["json"] = introspectionResponse
 			c.ServeJSON()
 			return
 		}
@@ -379,7 +393,6 @@ func (c *ApiController) IntrospectToken() {
 			Scope:     jwtToken.Scope,
 			ClientId:  clientId,
 			Username:  jwtToken.Name,
-			TokenType: jwtToken.TokenType,
 			Exp:       jwtToken.ExpiresAt.Unix(),
 			Iat:       jwtToken.IssuedAt.Unix(),
 			Nbf:       jwtToken.NotBefore.Unix(),
@@ -390,19 +403,7 @@ func (c *ApiController) IntrospectToken() {
 		}
 	}
 
-	if tokenTypeHint == "" {
-		token, err = object.GetTokenByTokenValue(tokenValue, introspectionResponse.TokenType)
-		if err != nil {
-			c.ResponseTokenError(err.Error())
-			return
-		}
-		if token == nil {
-			c.Data["json"] = &object.IntrospectionResponse{Active: false}
-			c.ServeJSON()
-			return
-		}
-	}
-	introspectionResponse.TokenType = token.TokenType
+	introspectionResponse.TokenType = strings.ToLower(token.TokenType)
 
 	c.Data["json"] = introspectionResponse
 	c.ServeJSON()

--- a/object/token.go
+++ b/object/token.go
@@ -121,29 +121,54 @@ func GetTokenByRefreshToken(refreshToken string) (*Token, error) {
 	return &token, nil
 }
 
+//		OPTIONAL.  A hint about the type of the token submitted for
+//		introspection.  The protected resource MAY pass this parameter to
+//		help the authorization server optimize the token lookup.  If the
+//		server is unable to locate the token using the given hint, it MUST
+//		extend its search across all of its supported token types.  An
+//		authorization server MAY ignore this parameter, particularly if it
+//		is able to detect the token type automatically.  Values for this
+//		field are defined in the "OAuth Token Type Hints" registry defined
+//		in OAuth Token Revocation [RFC7009].
+//	 Source: https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
 func GetTokenByTokenValue(tokenValue, tokenTypeHint string) (*Token, error) {
+	/// https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
 	switch tokenTypeHint {
 	case "access_token":
-	case "access-token":
 		token, err := GetTokenByAccessToken(tokenValue)
 		if err != nil {
 			return nil, err
 		}
-		if token != nil {
-			return token, nil
-		}
+
+		return token, nil
 	case "refresh_token":
-	case "refresh-token":
 		token, err := GetTokenByRefreshToken(tokenValue)
 		if err != nil {
 			return nil, err
 		}
+
+		return token, nil
+	case "":
+		token, err := GetTokenByAccessToken(tokenValue)
+		if err != nil {
+			return nil, err
+		}
+
+		if token == nil {
+			token, err = GetTokenByRefreshToken(tokenValue)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		if token != nil {
 			return token, nil
 		}
-	}
 
-	return nil, nil
+		return nil, nil
+	default:
+		return nil, nil
+	}
 }
 
 func updateUsedByCode(token *Token) bool {


### PR DESCRIPTION
Was issue #3396 and #3397
I overwrite function with [standart](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2)
After merge will open new issue about field `token_type_hint` and make it not necessary